### PR TITLE
🔒 Fix unsafe allowBackup setting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
 
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
🎯 **What:** Changed `android:allowBackup="true"` to `android:allowBackup="false"` in `app/src/main/AndroidManifest.xml`.

⚠️ **Risk:** The `android:allowBackup="true"` setting permits the app's data to be backed up via adb. If a device is compromised or unlocked, an attacker could extract sensitive app data, leading to a potential data breach.

🛡️ **Solution:** By setting `allowBackup="false"`, adb backup is explicitly disabled, protecting the app's data from this attack vector.

---
*PR created automatically by Jules for task [7499499828438555843](https://jules.google.com/task/7499499828438555843) started by @returnofthelambda*